### PR TITLE
Fix namespaces, improve assertEquals and fixtures

### DIFF
--- a/test/Container/Config/PugConfigTest.php
+++ b/test/Container/Config/PugConfigTest.php
@@ -45,15 +45,15 @@ class PugConfigTest extends TestCase
     public function testItShouldMergeDefaultConfigWithUserGivenConfig(): void
     {
         $pugConfig = PugConfig::createFromAntidotConfig(self::PUG_CONFIG);
-        $this->assertEquals(self::TITLE, $pugConfig->get('globals')['title']);
-        $this->assertEquals(self::EXTENSION, $pugConfig->templates()['extension']);
+        $this->assertSame(self::TITLE, $pugConfig->get('globals')['title']);
+        $this->assertSame(self::EXTENSION, $pugConfig->templates()['extension']);
     }
 
     public function testItShouldMergeDefaultConfigWithUserGivenConfigAndTemplatingConfigShouldOverridePugConfig(): void
     {
         $pugConfig = PugConfig::createFromAntidotConfig(array_merge(self::TEMPLATING_CONFIG, self::PUG_CONFIG));
-        $this->assertEquals(self::OTHER_TITLE, $pugConfig->get('globals')['title']);
-        $this->assertEquals(self::EXTENSION, $pugConfig->templates()['extension']);
+        $this->assertSame(self::OTHER_TITLE, $pugConfig->get('globals')['title']);
+        $this->assertSame(self::EXTENSION, $pugConfig->templates()['extension']);
     }
 
     public function testItShouldThrowAnExceptionWhenCallingInExistentConfigKey(): void

--- a/test/Container/PugFactoryTest.php
+++ b/test/Container/PugFactoryTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Antidot\Render\Phug\Container;
+namespace AntidotTest\Render\Phug\Container;
 
+use Antidot\Render\Phug\Container\PugFactory;
 use Antidot\Render\Phug\Container\Config\PugConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -13,7 +14,7 @@ class PugFactoryTest extends TestCase
     /** @var \PHPUnit\Framework\MockObject\MockObject|ContainerInterface */
     private $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = $this->createMock(ContainerInterface::class);
         $this->container->expects($this->once())
@@ -29,7 +30,7 @@ class PugFactoryTest extends TestCase
         $this->assertEquals(PugConfig::DEFAULT_PUG_CONFIG['pugjs'], $pug->getOption('pugjs'));
         $this->assertEquals(PugConfig::DEFAULT_PUG_CONFIG['localsJsonFile'], $pug->getOption('localsJsonFile'));
         $this->assertEquals(PugConfig::DEFAULT_PUG_CONFIG['pretty'], $pug->getOption('pretty'));
-        $this->assertEquals(PugConfig::DEFAULT_PUG_CONFIG['cache'], $pug->getOption('cache'));
-        $this->assertEquals(PugConfig::DEFAULT_PUG_CONFIG['expressionLanguage'], $pug->getOption('expressionLanguage'));
+        $this->assertSame(PugConfig::DEFAULT_PUG_CONFIG['cache'], $pug->getOption('cache'));
+        $this->assertSame(PugConfig::DEFAULT_PUG_CONFIG['expressionLanguage'], $pug->getOption('expressionLanguage'));
     }
 }

--- a/test/Container/PugRendererFactoryTest.php
+++ b/test/Container/PugRendererFactoryTest.php
@@ -3,8 +3,9 @@
 declare(strict_types=1);
 
 
-namespace Antidot\Render\Phug\Container;
+namespace AntidotTest\Render\Phug\Container;
 
+use Antidot\Render\Phug\Container\PugRendererFactory;
 use Antidot\Render\TemplateRenderer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -15,7 +16,7 @@ class PugRendererFactoryTest extends TestCase
     /** @var \PHPUnit\Framework\MockObject\MockObject|ContainerInterface */
     private $container;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = $this->createMock(ContainerInterface::class);
         $this->container->expects($this->exactly(2))

--- a/test/PugTemplateRendererTest.php
+++ b/test/PugTemplateRendererTest.php
@@ -3,8 +3,9 @@
 declare(strict_types=1);
 
 
-namespace Antidot\Render\Phug;
+namespace AntidotTest\Render\Phug;
 
+use Antidot\Render\Phug\PugTemplateRenderer;
 use Antidot\Render\Phug\Container\Config\PugConfig;
 use PHPUnit\Framework\TestCase;
 use Pug;
@@ -14,7 +15,7 @@ class PugTemplateRendererTest extends TestCase
     /** @var \PHPUnit\Framework\MockObject\MockObject|Pug */
     private $pug;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->pug = $this->createMock(Pug::class);
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/9.3/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.
- Using the `assertSame` to replace `assertEquals` and it can make assertion value equals strict.
- Fix `AntidotTest\Render\Phug\Container;` and `AntidotTest\Render\Phug;` namespaces.